### PR TITLE
feat: add BLIK payment support via Stripe

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@mui/icons-material": "^5.5.x",
         "@mui/material": "^5.5.x",
         "@mui/styles": "^5.5.x",
-        "@stripe/react-stripe-js": "^1.13.0",
+        "@stripe/react-stripe-js": "1.13.0",
         "@stripe/stripe-js": "^1.54.2",
         "react": "^17.x",
         "react-async-hook": "^4.0.0",
@@ -38,6 +38,7 @@
         "@mui/icons-material": "^5.5.x",
         "@mui/material": "^5.5.x",
         "@mui/styles": "^5.5.x",
+        "@stripe/react-stripe-js": "^1.13.0",
         "@stripe/stripe-js": "^1.54.2",
         "react": "^17.x",
         "react-dom": "^17.x"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@variocube/payment-js",
-  "version": "2.2.0",
+  "version": "2.2.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@variocube/payment-js",
-      "version": "2.2.0",
+      "version": "2.2.3",
       "license": "ISC",
       "dependencies": {
         "@emotion/react": "^11.8.2",
@@ -14,8 +14,8 @@
         "@mui/icons-material": "^5.5.x",
         "@mui/material": "^5.5.x",
         "@mui/styles": "^5.5.x",
-        "@stripe/react-stripe-js": "^1.7.x",
-        "@stripe/stripe-js": "^1.25.x",
+        "@stripe/react-stripe-js": "^1.13.0",
+        "@stripe/stripe-js": "^1.54.2",
         "react": "^17.x",
         "react-async-hook": "^4.0.0",
         "react-dom": "^17.x"
@@ -38,8 +38,7 @@
         "@mui/icons-material": "^5.5.x",
         "@mui/material": "^5.5.x",
         "@mui/styles": "^5.5.x",
-        "@stripe/react-stripe-js": "^1.7.x",
-        "@stripe/stripe-js": "^1.25.x",
+        "@stripe/stripe-js": "^1.54.2",
         "react": "^17.x",
         "react-dom": "^17.x"
       }
@@ -885,22 +884,24 @@
       }
     },
     "node_modules/@stripe/react-stripe-js": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@stripe/react-stripe-js/-/react-stripe-js-1.7.0.tgz",
-      "integrity": "sha512-L20v8Jq0TDZFL2+y+uXD751t6q9SalSFkSYZpmZ2VWrGZGK7HAGfRQ804dzYSSr5fGenW6iz6y7U0YKfC/TK3g==",
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/@stripe/react-stripe-js/-/react-stripe-js-1.13.0.tgz",
+      "integrity": "sha512-6v2VVYorWalmlHF5DIlHp5xtFzX9rY36N4d7kyS8D/4jxvZYHOKJj96LCQfwuFi/o19/dCX8rxt/ct+pF9kI8A==",
+      "license": "MIT",
       "dependencies": {
         "prop-types": "^15.7.2"
       },
       "peerDependencies": {
-        "@stripe/stripe-js": "^1.20.3",
-        "react": "^16.8.0 || ^17.0.0",
-        "react-dom": "^16.8.0 || ^17.0.0"
+        "@stripe/stripe-js": "^1.41.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/@stripe/stripe-js": {
-      "version": "1.25.0",
-      "resolved": "https://registry.npmjs.org/@stripe/stripe-js/-/stripe-js-1.25.0.tgz",
-      "integrity": "sha512-cywIoKu3sJnBPQ1eKi3BzFHWslA2ePqHvQhcxp7iYYlo1tWcVgEKTSh7y7hb6GoR4TyT3DwlK4v1vOZpVg8u4Q=="
+      "version": "1.54.2",
+      "resolved": "https://registry.npmjs.org/@stripe/stripe-js/-/stripe-js-1.54.2.tgz",
+      "integrity": "sha512-R1PwtDvUfs99cAjfuQ/WpwJ3c92+DAMy9xGApjqlWQMj0FKQabUAys2swfTRNzuYAYJh7NqK2dzcYVNkKLEKUg==",
+      "license": "MIT"
     },
     "node_modules/@types/body-parser": {
       "version": "1.19.2",
@@ -6505,17 +6506,17 @@
       "integrity": "sha512-q/ytXxO5NKvyT37pmisQAItCFqA7FD/vNb8dgaJy3/630Fsc+Mz9/9f2SziBoIZ30TJooXyTwZmhi1zjXmObYg=="
     },
     "@stripe/react-stripe-js": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@stripe/react-stripe-js/-/react-stripe-js-1.7.0.tgz",
-      "integrity": "sha512-L20v8Jq0TDZFL2+y+uXD751t6q9SalSFkSYZpmZ2VWrGZGK7HAGfRQ804dzYSSr5fGenW6iz6y7U0YKfC/TK3g==",
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/@stripe/react-stripe-js/-/react-stripe-js-1.13.0.tgz",
+      "integrity": "sha512-6v2VVYorWalmlHF5DIlHp5xtFzX9rY36N4d7kyS8D/4jxvZYHOKJj96LCQfwuFi/o19/dCX8rxt/ct+pF9kI8A==",
       "requires": {
         "prop-types": "^15.7.2"
       }
     },
     "@stripe/stripe-js": {
-      "version": "1.25.0",
-      "resolved": "https://registry.npmjs.org/@stripe/stripe-js/-/stripe-js-1.25.0.tgz",
-      "integrity": "sha512-cywIoKu3sJnBPQ1eKi3BzFHWslA2ePqHvQhcxp7iYYlo1tWcVgEKTSh7y7hb6GoR4TyT3DwlK4v1vOZpVg8u4Q=="
+      "version": "1.54.2",
+      "resolved": "https://registry.npmjs.org/@stripe/stripe-js/-/stripe-js-1.54.2.tgz",
+      "integrity": "sha512-R1PwtDvUfs99cAjfuQ/WpwJ3c92+DAMy9xGApjqlWQMj0FKQabUAys2swfTRNzuYAYJh7NqK2dzcYVNkKLEKUg=="
     },
     "@types/body-parser": {
       "version": "1.19.2",

--- a/package.json
+++ b/package.json
@@ -23,8 +23,8 @@
     "@mui/icons-material": "^5.5.x",
     "@mui/material": "^5.5.x",
     "@mui/styles": "^5.5.x",
-    "@stripe/react-stripe-js": "^1.7.x",
-    "@stripe/stripe-js": "^1.25.x",
+    "@stripe/react-stripe-js": "^1.13.0",
+    "@stripe/stripe-js": "^1.54.2",
     "react": "^17.x",
     "react-async-hook": "^4.0.0",
     "react-dom": "^17.x"
@@ -47,8 +47,8 @@
     "@mui/icons-material": "^5.5.x",
     "@mui/material": "^5.5.x",
     "@mui/styles": "^5.5.x",
-    "@stripe/react-stripe-js": "^1.7.x",
-    "@stripe/stripe-js": "^1.25.x",
+    "@stripe/react-stripe-js": "^1.13.0",
+    "@stripe/stripe-js": "^1.54.2",
     "react": "^17.x",
     "react-dom": "^17.x"
   },

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@mui/icons-material": "^5.5.x",
     "@mui/material": "^5.5.x",
     "@mui/styles": "^5.5.x",
-    "@stripe/react-stripe-js": "^1.13.0",
+    "@stripe/react-stripe-js": "1.13.0",
     "@stripe/stripe-js": "^1.54.2",
     "react": "^17.x",
     "react-async-hook": "^4.0.0",

--- a/src/flow/payment.tsx
+++ b/src/flow/payment.tsx
@@ -72,7 +72,7 @@ export function PaymentMethodList({paymentMethods, currency, onPaymentError, onP
                                                 <Avatar style={styles.primaryBg}><RefreshIcon style={{ color: '#fff' }}/></Avatar>
                                             </ListItemAvatar>
                                             <ListItemText
-                                                primary={(messages as any)['StorePaymentMethod' + method.stripe.type]}
+                                                primary={storedPaymentMethodLabel(method.stripe.type)}
                                                 secondary={method.stripe?.last4Digits}
                                             />
                                         </ListItem>
@@ -85,8 +85,8 @@ export function PaymentMethodList({paymentMethods, currency, onPaymentError, onP
                                                 </Avatar>
                                             </ListItemAvatar>
                                             <ListItemText
-                                                primary={(messages as any)['PaymentMethod' + method.stripe.type]}
-                                                secondary={(messages as any)['PaymentMethod' + method.stripe.type + 'Description']}
+                                                primary={paymentMethodLabel(method.stripe.type)}
+                                                secondary={paymentMethodDescription(method.stripe.type)}
                                             />
                                         </ListItem>
                                     )}
@@ -140,6 +140,43 @@ export function PaymentMethodList({paymentMethods, currency, onPaymentError, onP
             </Paper>
         </Fragment>
     );
+}
+
+function storedPaymentMethodLabel(type: PaymentType): string {
+    switch (type) {
+        case PaymentType.Cards:
+            return messages.StorePaymentMethodCards;
+        case PaymentType.SepaDirectDebit:
+            return messages.StorePaymentMethodSepaDirectDebit;
+        default:
+            return '';
+    }
+}
+
+function paymentMethodLabel(type: PaymentType): string {
+    switch (type) {
+        case PaymentType.Cards:
+            return messages.PaymentMethodCards;
+        case PaymentType.SepaDirectDebit:
+            return messages.PaymentMethodSepaDirectDebit;
+        case PaymentType.Blik:
+            return messages.PaymentMethodBlik;
+        default:
+            return '';
+    }
+}
+
+function paymentMethodDescription(type: PaymentType): string {
+    switch (type) {
+        case PaymentType.Cards:
+            return messages.PaymentMethodCardsDescription;
+        case PaymentType.SepaDirectDebit:
+            return messages.PaymentMethodSepaDirectDebitDescription;
+        case PaymentType.Blik:
+            return messages.PaymentMethodBlikDescription;
+        default:
+            return '';
+    }
 }
 
 function renderPaymentTypeIcon(type: PaymentType) {

--- a/src/flow/payment.tsx
+++ b/src/flow/payment.tsx
@@ -14,7 +14,7 @@ import {
 } from "@mui/material";
 import {resources} from "../resources";
 import {PaypalPayment} from "./paypal";
-import {StripeCardPayment, StripePaymentRequest, StripeSepaPayment} from "./stripe";
+import {StripeBlikPayment, StripeCardPayment, StripePaymentRequest, StripeSepaPayment} from "./stripe";
 import {PaymentMethod, PaymentStatus, PaymentType, StripeClientSecret} from "../types";
 import {styles} from "../theme";
 import {EuroIcon, ImageIcon, LayersIcon, PaymentIcon, RefreshIcon} from "../icons";
@@ -77,7 +77,7 @@ export function PaymentMethodList({paymentMethods, currency, onPaymentError, onP
                                             />
                                         </ListItem>
                                     )}
-                                    {(method.stripe && method.stripe.last4Digits === undefined && [PaymentType.Cards, PaymentType.SepaDirectDebit].indexOf(method.stripe.type) > -1) && (
+                                    {(method.stripe && method.stripe.last4Digits === undefined && [PaymentType.Cards, PaymentType.SepaDirectDebit, PaymentType.Blik].indexOf(method.stripe.type) > -1) && (
                                         <ListItem button disabled={disabled} onClick={() => handleMethodSelection(method, false)}>
                                             <ListItemAvatar>
                                                 <Avatar style={styles.primaryBg}>
@@ -148,6 +148,8 @@ function renderPaymentTypeIcon(type: PaymentType) {
             return <PaymentIcon style={{ color: '#fff' }}/>;
         case PaymentType.SepaDirectDebit:
             return <EuroIcon style={{ color: '#fff' }}/>;
+        case PaymentType.Blik:
+            return <PaymentIcon style={{ color: '#fff' }}/>;
         case PaymentType.PayPal:
             return <PayPalIcon style={{ height: '50%', overflow: 'hidden' }} />;
         case PaymentType.PaymentRequest:
@@ -182,6 +184,12 @@ export function PaymentView(props: PaymentViewProps) {
                                             stripeClientSecret={stripeClientSecret}
                                             onPaymentError={e => onPaymentError(new Error('Failed to make Stripe Sepa Payment, error: ' + e.message))}
                                             onPaymentConfirmed={(status, saveMethod) => onPaymentConfirmed(status, paymentMethod, saveMethod)}
+                                            publicKey={paymentMethod.publicKey}/>;
+                break;
+            case PaymentType.Blik:
+                method = <StripeBlikPayment stripeClientSecret={stripeClientSecret}
+                                            onPaymentError={e => onPaymentError(new Error('Failed to make Stripe BLIK Payment, error: ' + e.message))}
+                                            onPaymentConfirmed={status => onPaymentConfirmed(status, paymentMethod)}
                                             publicKey={paymentMethod.publicKey}/>;
                 break;
             default:

--- a/src/flow/stripe.tsx
+++ b/src/flow/stripe.tsx
@@ -361,6 +361,152 @@ export const StripeSepaPayment = ({publicKey, payeeName, stripeClientSecret, onP
 
 
 /**
+ * BLIK PAYMENT ELEMENT
+ * Code-based payment for customers in Poland (PLN). No Stripe Element required.
+ */
+interface BlikPaymentFormProps {
+    stripe: Stripe;
+    stripeClientSecret: StripeClientSecret;
+    onPaymentError: (error: StripeJs.StripeError) => void;
+    onPaymentConfirmed: (paymentIntent: PaymentIntent) => void;
+}
+
+const BlikPaymentForm = ({stripe, stripeClientSecret, onPaymentError, onPaymentConfirmed}: BlikPaymentFormProps) => {
+    const [billingDetails, setBillingDetails] = useState<{ name: string, email: string }>({ name: '', email: '' });
+    const [code, setCode] = useState('');
+    const [processing, setProcessing] = useState(false);
+    const [error, setError] = useState<string>();
+
+    const handleSubmit = useCallback((event?: any) => {
+        if (event) event.preventDefault();
+        if (!/^\d{6}$/.test(code)) {
+            setError(messages.PaymentFormBlikCodeInvalid);
+            return;
+        }
+        if (billingDetails.name.trim().length === 0 || billingDetails.email.trim().length === 0) {
+            const top = document.getElementById('payment-flow-box');
+            if (top) {
+                top.scrollIntoView();
+            }
+            return;
+        }
+        setProcessing(true);
+        setError(undefined);
+        stripe.confirmBlikPayment(stripeClientSecret.clientSecret, {
+            payment_method: { blik: {}, billing_details: billingDetails },
+            payment_method_options: { blik: { code } }
+        })
+            .then(({error, paymentIntent}) => {
+                let confirmed = false;
+                if (paymentIntent && (paymentIntent.status === 'processing' || paymentIntent.status === 'succeeded')) {
+                    confirmed = true;
+                }
+                if (error) {
+                    if (error.payment_intent && (error.payment_intent.status === 'processing' || error.payment_intent.status === 'succeeded')) {
+                        confirmed = true;
+                        paymentIntent = error.payment_intent;
+                    } else {
+                        console.error('[error]', error);
+                        setError(error.message);
+                        onPaymentError(error);
+                    }
+                }
+                if (confirmed && paymentIntent) {
+                    onPaymentConfirmed(paymentIntent);
+                }
+            })
+            .finally(() => setProcessing(false));
+    }, [stripe, stripeClientSecret, code, billingDetails, onPaymentError, onPaymentConfirmed]);
+
+    const onBillingDetailsChange = (event: any) => {
+        setBillingDetails({
+            ...billingDetails,
+            [event.target.name]: event.target.value
+        });
+    };
+
+    return (
+        <div>
+            <Typography variant="h6" align="center">
+                <PaymentIcon style={styles.paymentTitleIcon as any}/>
+                <strong>{messages.PaymentMethodBlik}</strong>
+            </Typography>
+            <Box my={2}/>
+            <form onSubmit={handleSubmit}>
+                <Grid container spacing={1}>
+                    <Grid item xs={12} md={6}>
+                        <TextField fullWidth required
+                                   label={messages.Name} variant="outlined"
+                                   name="name" value={billingDetails.name}
+                                   onChange={onBillingDetailsChange}/>
+                    </Grid>
+                    <Grid item xs={12} md={6}>
+                        <TextField fullWidth required
+                                   label={messages.Email} variant="outlined" type="email"
+                                   name="email" value={billingDetails.email}
+                                   onChange={onBillingDetailsChange}/>
+                    </Grid>
+                </Grid>
+                <Box my={1}/>
+                <TextField fullWidth required
+                           label={messages.PaymentFormBlikCode} variant="outlined"
+                           value={code}
+                           inputProps={{ inputMode: 'numeric', pattern: '[0-9]*', maxLength: 6 }}
+                           onChange={e => setCode(e.target.value.replace(/\D/g, '').slice(0, 6))}/>
+                <Box my={1}/>
+                <Typography variant="body2" align="center" style={{ fontSize: '0.8rem' }}>
+                    {messages.PaymentFormBlikHint}
+                </Typography>
+                <Box mt={2} style={{ textAlign: 'center'}}>
+                    <Button type="submit" style={{ minWidth: 150 }} size="large" variant="outlined" color="primary" disabled={!stripe || processing}>Pay</Button>
+                </Box>
+            </form>
+            { processing && (
+                <Box mt={2}>
+                    <Typography variant="body1" align="center">{messages.ProcessingPayment}</Typography>
+                </Box>
+            )}
+            { error && (
+                <Box mt={2}>
+                    <Alert severity="error">{error}</Alert>
+                </Box>
+            )}
+        </div>
+    )
+}
+
+interface StripeBlikPaymentProps {
+    publicKey: string;
+    stripeClientSecret: StripeClientSecret;
+    onPaymentError: (error: StripeJs.StripeError) => void;
+    onPaymentConfirmed: (status: PaymentStatus) => void;
+}
+
+export const StripeBlikPayment = ({publicKey, stripeClientSecret, onPaymentError, onPaymentConfirmed}: StripeBlikPaymentProps) => {
+    const [stripe, setStripe] = useState<Stripe>();
+
+    useEffect(() => {
+        loadStripe(publicKey)
+            .then(s => setStripe(s || undefined));
+    }, []);
+
+    return (
+        (!stripe) ?
+            <Typography>Loading...</Typography> :
+            <Elements stripe={stripe}>
+                <ElementsConsumer>
+                    {({stripe}: any) => (
+                        <BlikPaymentForm stripe={stripe} stripeClientSecret={stripeClientSecret}
+                                         onPaymentError={onPaymentError}
+                                         onPaymentConfirmed={paymentIntent => handlePaymentConfirmed(paymentIntent, false, onPaymentConfirmed)}/>
+                    )}
+                </ElementsConsumer>
+            </Elements>
+    )
+}
+
+
+/**
  * PAYMENT REQUEST
  * For Apple Pay, Google Pay and Microsoft Pay
  */

--- a/src/flow/stripe.tsx
+++ b/src/flow/stripe.tsx
@@ -383,13 +383,6 @@ const BlikPaymentForm = ({stripe, stripeClientSecret, onPaymentError, onPaymentC
             setError(messages.PaymentFormBlikCodeInvalid);
             return;
         }
-        if (billingDetails.name.trim().length === 0 || billingDetails.email.trim().length === 0) {
-            const top = document.getElementById('payment-flow-box');
-            if (top) {
-                top.scrollIntoView();
-            }
-            return;
-        }
         setProcessing(true);
         setError(undefined);
         stripe.confirmBlikPayment(stripeClientSecret.clientSecret, {

--- a/src/resources.ts
+++ b/src/resources.ts
@@ -116,6 +116,31 @@ export const resources = new Resources(language || Language.DE, {
         [Language.DE]: "Für Kunden im einheitlichen Euro-Zahlungsraum.",
         [Language.EE]: 'Ühtse euromaksete piirkonna klientidele.'
     },
+    PaymentMethodBlik: {
+        [Language.EN]: "BLIK",
+        [Language.DE]: "BLIK",
+        [Language.EE]: "BLIK"
+    },
+    PaymentMethodBlikDescription: {
+        [Language.EN]: "Pay with a BLIK code from your banking app (Poland).",
+        [Language.DE]: "Zahlen Sie mit einem BLIK-Code aus Ihrer Banking-App (Polen).",
+        [Language.EE]: "Maksa oma pangarakenduse BLIK-koodiga (Poola)."
+    },
+    PaymentFormBlikCode: {
+        [Language.EN]: "BLIK code (6 digits)",
+        [Language.DE]: "BLIK-Code (6 Ziffern)",
+        [Language.EE]: "BLIK-kood (6 numbrit)"
+    },
+    PaymentFormBlikCodeInvalid: {
+        [Language.EN]: "Please enter a valid 6-digit BLIK code.",
+        [Language.DE]: "Bitte geben Sie einen gültigen 6-stelligen BLIK-Code ein.",
+        [Language.EE]: "Palun sisestage kehtiv 6-kohaline BLIK-kood."
+    },
+    PaymentFormBlikHint: {
+        [Language.EN]: "After submitting, confirm the payment in your banking app.",
+        [Language.DE]: "Bestätigen Sie die Zahlung nach dem Absenden in Ihrer Banking-App.",
+        [Language.EE]: "Pärast esitamist kinnitage makse oma pangarakenduses."
+    },
     PaymentMethodNotSupported: {
         [Language.EN]: "Sorry! We don't support the selected payment method yet. Please try again with a different one.",
         [Language.DE]: "Leider unterstützen wir die gewählte Zahlungsmethode noch nicht. Bitte versuchen Sie es noch einmal mit einer anderen Zahlungsmethode.",

--- a/src/resources.ts
+++ b/src/resources.ts
@@ -2,6 +2,7 @@ export enum Language {
     EN = 'en',
     DE = 'de',
     EE = "et",
+    PL = "pl",
 }
 
 export type MultiLingualString = {
@@ -70,286 +71,343 @@ export const resources = new Resources(language || Language.DE, {
         [Language.EN]: "Initiate payment. Please wait...",
         [Language.DE]: "Zahlung wird vorbereiten. Bitte warten... ",
         [Language.EE]: "Algatage makse. Palun oodake...",
+        [Language.PL]: "Inicjowanie płatności. Proszę czekać...",
     },
     InvalidPayment: {
         [Language.EN]: "Could not start payment. Please contact support!",
         [Language.DE]: "Fehler beim Starten der Zahlung. Bitte kontaktieren Sie uns.",
         [Language.EE]: "Makseid ei saanud alustada. Palun võtke ühendust klienditoega!",
+        [Language.PL]: "Nie udało się rozpocząć płatności. Skontaktuj się z pomocą techniczną!",
     },
     SelectPaymentMethod: {
         [Language.EN]: "Please select a payment method:",
         [Language.DE]: "Bitte wählen Sie eine Zahlungsmethode aus:",
-        [Language.EE]: "Palun valige oma makseviis:"
+        [Language.EE]: "Palun valige oma makseviis:",
+        [Language.PL]: "Wybierz metodę płatności:"
     },
     LoadingPayment: {
         [Language.EN]: "Loading payment. Please wait...",
         [Language.DE]: "Zahlung wird geladen. Bitte warten... ",
         [Language.EE]: "Makse laadimine. Palun oodake...",
+        [Language.PL]: "Ładowanie płatności. Proszę czekać...",
     },
     StorePaymentMethodCards: {
         [Language.EN]: "Stored Credit Card",
         [Language.DE]: "Gespeicherte Kreditkarte",
-        [Language.EE]: "Salvestatud krediitkaart"
+        [Language.EE]: "Salvestatud krediitkaart",
+        [Language.PL]: "Zapisana karta kredytowa"
     },
     StorePaymentMethodSepaDirectDebit: {
         [Language.EN]: "Stored SEPA Direct Debit",
         [Language.DE]: "Gespeichertes SEPA-Lastschriftverfahren",
-        [Language.EE]: "Salvestatud SEPA otsekorraldus"
+        [Language.EE]: "Salvestatud SEPA otsekorraldus",
+        [Language.PL]: "Zapisane polecenie zapłaty SEPA"
     },
     PaymentMethodCards: {
         [Language.EN]: "Credit Card",
         [Language.DE]: "Kreditkarte",
         [Language.EE]: "Krediitkaart",
+        [Language.PL]: "Karta kredytowa",
     },
     PaymentMethodCardsDescription: {
         [Language.EN]: "Mastercard, VISA, Diners Club, etc.",
         [Language.DE]: "Mastercard, VISA, Diners Club, usw.",
-        [Language.EE]: 'Mastercard, VISA, Diners Club jne.'
+        [Language.EE]: 'Mastercard, VISA, Diners Club jne.',
+        [Language.PL]: "Mastercard, VISA, Diners Club itp."
     },
     PaymentMethodSepaDirectDebit: {
         [Language.EN]: "SEPA Direct Debit",
         [Language.DE]: "SEPA-Lastschriftverfahren",
-        [Language.EE]: 'SEPA otsekorraldus'
+        [Language.EE]: 'SEPA otsekorraldus',
+        [Language.PL]: "Polecenie zapłaty SEPA"
     },
     PaymentMethodSepaDirectDebitDescription: {
         [Language.EN]: "For customers in the Single Euro Payments Area.",
         [Language.DE]: "Für Kunden im einheitlichen Euro-Zahlungsraum.",
-        [Language.EE]: 'Ühtse euromaksete piirkonna klientidele.'
+        [Language.EE]: 'Ühtse euromaksete piirkonna klientidele.',
+        [Language.PL]: "Dla klientów w jednolitym obszarze płatności w euro."
     },
     PaymentMethodBlik: {
         [Language.EN]: "BLIK",
         [Language.DE]: "BLIK",
-        [Language.EE]: "BLIK"
+        [Language.EE]: "BLIK",
+        [Language.PL]: "BLIK"
     },
     PaymentMethodBlikDescription: {
         [Language.EN]: "Pay with a BLIK code from your banking app (Poland).",
         [Language.DE]: "Zahlen Sie mit einem BLIK-Code aus Ihrer Banking-App (Polen).",
-        [Language.EE]: "Maksa oma pangarakenduse BLIK-koodiga (Poola)."
+        [Language.EE]: "Maksa oma pangarakenduse BLIK-koodiga (Poola).",
+        [Language.PL]: "Zapłać kodem BLIK z aplikacji bankowej."
     },
     PaymentFormBlikCode: {
         [Language.EN]: "BLIK code (6 digits)",
         [Language.DE]: "BLIK-Code (6 Ziffern)",
-        [Language.EE]: "BLIK-kood (6 numbrit)"
+        [Language.EE]: "BLIK-kood (6 numbrit)",
+        [Language.PL]: "Kod BLIK (6 cyfr)"
     },
     PaymentFormBlikCodeInvalid: {
         [Language.EN]: "Please enter a valid 6-digit BLIK code.",
         [Language.DE]: "Bitte geben Sie einen gültigen 6-stelligen BLIK-Code ein.",
-        [Language.EE]: "Palun sisestage kehtiv 6-kohaline BLIK-kood."
+        [Language.EE]: "Palun sisestage kehtiv 6-kohaline BLIK-kood.",
+        [Language.PL]: "Wprowadź prawidłowy 6-cyfrowy kod BLIK."
     },
     PaymentFormBlikHint: {
         [Language.EN]: "After submitting, confirm the payment in your banking app.",
         [Language.DE]: "Bestätigen Sie die Zahlung nach dem Absenden in Ihrer Banking-App.",
-        [Language.EE]: "Pärast esitamist kinnitage makse oma pangarakenduses."
+        [Language.EE]: "Pärast esitamist kinnitage makse oma pangarakenduses.",
+        [Language.PL]: "Po zatwierdzeniu potwierdź płatność w aplikacji bankowej."
     },
     PaymentMethodNotSupported: {
         [Language.EN]: "Sorry! We don't support the selected payment method yet. Please try again with a different one.",
         [Language.DE]: "Leider unterstützen wir die gewählte Zahlungsmethode noch nicht. Bitte versuchen Sie es noch einmal mit einer anderen Zahlungsmethode.",
-        [Language.EE]: 'Vabandust! Me ei toeta veel teie valitud makseviisi. Palun proovige uuesti teise meetodiga.'
+        [Language.EE]: 'Vabandust! Me ei toeta veel teie valitud makseviisi. Palun proovige uuesti teise meetodiga.',
+        [Language.PL]: "Przepraszamy! Nie obsługujemy jeszcze wybranej metody płatności. Spróbuj ponownie z inną."
     },
     PaymentFormCardsDescription: {
         [Language.EN]: "Please provide your card information:",
         [Language.DE]: "Bitte geben Sie Ihre Karteninformationen ein:",
-        [Language.EE]: 'Palun andke meile oma kaardi andmed:'
+        [Language.EE]: 'Palun andke meile oma kaardi andmed:',
+        [Language.PL]: "Podaj dane swojej karty:"
     },
     PaymentFormSavePaymentMethod: {
         [Language.EN]: "Save my current payment method for next checkout.",
         [Language.DE]: "Zahlungsmethode für weitere Zahlungen speichern.",
-        [Language.EE]: 'Salvesta minu praegune makseviis järgmiseks maksekorraks.'
+        [Language.EE]: 'Salvesta minu praegune makseviis järgmiseks maksekorraks.',
+        [Language.PL]: "Zapisz moją obecną metodę płatności na następny zakup."
     },
     PaymentFormSepaDirectDebitAcceptance: {
         [Language.EN]: "By providing the IBAN and confirming this payment, I authorize/ We authorize (A) %PAYEE% to collect payments from my/our bank account by SEPA Direct Debit. At the same time (B) I/we instruct my/our credit institution to honour the direct debits drawn by %PAYEE% to my/our bank account.",
         [Language.DE]: "Durch Angabe der IBAN und Bestätigung dieser Zahlung, ermächtige/n ich/wir (A) %PAYEE%, Zahlungen von meinem/ unserem Konto mittels Lastschrift einzuziehen. Zugleich (B) weise ich mein/ weisen wir unser Kreditinstitut an, die von %PAYEE% auf mein/ unser Konto gezogenen Lastschriften einzulösen.",
-        [Language.EE]: 'IBANi esitades ja seda makset kinnitades volitan/ volitame (A) %PAYEE% koguma makseid minu/meie pangakontolt SEPA otsekorralduse teel. Samal ajal (B) annan/esitame oma krediidiasutusele korralduse täita %PAYEE% poolt minu/meie pangakontole tehtud otsekorraldusi.'
+        [Language.EE]: 'IBANi esitades ja seda makset kinnitades volitan/ volitame (A) %PAYEE% koguma makseid minu/meie pangakontolt SEPA otsekorralduse teel. Samal ajal (B) annan/esitame oma krediidiasutusele korralduse täita %PAYEE% poolt minu/meie pangakontole tehtud otsekorraldusi.',
+        [Language.PL]: "Podając numer IBAN i potwierdzając tę płatność, upoważniam/upoważniamy (A) %PAYEE% do pobierania płatności z mojego/naszego rachunku bankowego w drodze polecenia zapłaty SEPA. Jednocześnie (B) polecam/polecamy mojej/naszej instytucji kredytowej realizację poleceń zapłaty obciążających mój/nasz rachunek bankowy wystawionych przez %PAYEE%."
     },
     ProcessingPayment: {
         [Language.EN]: "Processing your payment. Please wait...",
         [Language.DE]: "Ihre Zahlung wird bearbeitet. Bitte warten...",
-        [Language.EE]: 'Teie makse töötlemine. Palun oodake...'
+        [Language.EE]: 'Teie makse töötlemine. Palun oodake...',
+        [Language.PL]: "Przetwarzanie płatności. Proszę czekać..."
     },
     PaymentCanceled: {
         [Language.EN]: "Payment canceled.",
         [Language.DE]: "Die Zahlung wurde storniert.",
-        [Language.EE]: 'Maksmine tühistatud.'
+        [Language.EE]: 'Maksmine tühistatud.',
+        [Language.PL]: "Płatność anulowana."
     },
     PaymentSucceeded: {
         [Language.EN]: "Payment succeeded. Thank you very much.",
         [Language.DE]: "Zahlung erfolgreich. Vielen Dank.",
-        [Language.EE]: 'Maksmine õnnestus. Tänan teid väga.'
+        [Language.EE]: 'Maksmine õnnestus. Tänan teid väga.',
+        [Language.PL]: "Płatność zakończona sukcesem. Dziękujemy bardzo."
     },
     PaymentInProcessing: {
         [Language.EN]: "Your payment is being processed...",
         [Language.DE]: "Ihre Zahlung wird bearbeitet...",
-        [Language.EE]: 'Teie makset töödeldakse...'
+        [Language.EE]: 'Teie makset töödeldakse...',
+        [Language.PL]: "Twoja płatność jest przetwarzana..."
     },
     PaymentFailed: {
         [Language.EN]: "There was a failure when charging your payment method.",
         [Language.DE]: "Bei der Bearbeitung Ihrer Zahlung ist ein Fehler aufgetreten.",
-        [Language.EE]: 'Teie makse laadimisel oli ebaõnnestunud katse.'
+        [Language.EE]: 'Teie makse laadimisel oli ebaõnnestunud katse.',
+        [Language.PL]: "Wystąpił błąd podczas obciążania Twojej metody płatności."
     },
     PaypalFailedToLoad: {
         [Language.EN]: "Could not load PayPal payment method. Please try a different method.",
         [Language.DE]: "Leider können wir die Zahlungsmethode PayPal nicht laden. Bitte versuchen Sie eine andere Zahlungsmethode.",
-        [Language.EE]: 'Ei saanud laadida PayPal makseviisi. Palun proovige teist meetodit.'
+        [Language.EE]: 'Ei saanud laadida PayPal makseviisi. Palun proovige teist meetodit.',
+        [Language.PL]: "Nie udało się załadować metody płatności PayPal. Spróbuj innej metody."
     },
     PaypalFailedToCreateOrder: {
         [Language.EN]: 'Could not create order for PayPal payment.',
         [Language.DE]: 'Leider können wir keine Bestellung bei PayPal anlegen.',
-        [Language.EE]: 'Ei saanud luua tellimust PayPal-makse jaoks.'
+        [Language.EE]: 'Ei saanud luua tellimust PayPal-makse jaoks.',
+        [Language.PL]: "Nie udało się utworzyć zamówienia dla płatności PayPal."
     },
     PaypalFailedToCaptureOrder: {
         [Language.EN]: 'Could not capture PayPal payment.',
         [Language.DE]: 'Leider konnten wir Ihre PayPal-Zahlung nicht verarbeiten.',
-        [Language.EE]: 'PayPal-makseid ei õnnestunud sisestada.'
+        [Language.EE]: 'PayPal-makseid ei õnnestunud sisestada.',
+        [Language.PL]: "Nie udało się zrealizować płatności PayPal."
     },
     Amount: {
         [Language.EN]: "Amount",
         [Language.DE]: "Betrag",
-        [Language.EE]: 'Summa'
+        [Language.EE]: 'Summa',
+        [Language.PL]: "Kwota"
     },
     Name: {
         [Language.EN]: "Name",
         [Language.DE]: "Name",
-        [Language.EE]: 'Nimi'
+        [Language.EE]: 'Nimi',
+        [Language.PL]: "Imię i nazwisko"
     },
     Email: {
         [Language.EN]: "Email Address",
         [Language.DE]: "E-Mail-Adresse",
-        [Language.EE]: 'E-posti aadress'
+        [Language.EE]: 'E-posti aadress',
+        [Language.PL]: "Adres e-mail"
     },
     Loading: {
         [Language.EN]: "Loading...",
         [Language.DE]: "Laden...",
-        [Language.EE]: 'Laadimine...'
+        [Language.EE]: 'Laadimine...',
+        [Language.PL]: "Ładowanie..."
     },
     Finish: {
         [Language.EN]: "Finish",
         [Language.DE]: "Beenden",
-        [Language.EE]: 'Lõpeta'
+        [Language.EE]: 'Lõpeta',
+        [Language.PL]: "Zakończ"
     },
     Back: {
         [Language.EN]: "Back",
         [Language.DE]: "Zurück",
-        [Language.EE]: 'Tagasi'
+        [Language.EE]: 'Tagasi',
+        [Language.PL]: "Wstecz"
     },
     Cancel: {
         [Language.EN]: "Cancel",
         [Language.DE]: "Abbrechen",
-        [Language.EE]: 'Tühista'
+        [Language.EE]: 'Tühista',
+        [Language.PL]: "Anuluj"
     },
     ReturnToMerchant: {
         [Language.EN]: "Return to merchant.",
         [Language.DE]: "Zurück zum Händler.",
-        [Language.EE]: 'Tagasi kaupmehe juurde.'
+        [Language.EE]: 'Tagasi kaupmehe juurde.',
+        [Language.PL]: "Powrót do sprzedawcy."
     },
     CancelAndReturnToMerchant: {
         [Language.EN]: "Cancel and return to merchant.",
         [Language.DE]: "Abbrechen und zurück zum Händler.",
-        [Language.EE]: 'Tühistage ja tagastage kaupmehele.'
+        [Language.EE]: 'Tühistage ja tagastage kaupmehele.',
+        [Language.PL]: "Anuluj i wróć do sprzedawcy."
     },
     ErrorCodeInvalidPayee: {
         [Language.EN]: 'Payment contains an invalid payee.',
         [Language.DE]: 'Die Zahlung enthält einen ungültigen Zahlungsempfänger.',
-        [Language.EE]: 'Makse sisaldab kehtetut makse saajat.'
+        [Language.EE]: 'Makse sisaldab kehtetut makse saajat.',
+        [Language.PL]: "Płatność zawiera nieprawidłowego odbiorcę."
     },
     ErrorCodePayeeNotConfiguredForStripe: {
         [Language.EN]: 'Payment methods (Cards) not supported.',
         [Language.DE]: 'Zahlungsmethode (Kreditkarten) wird nicht unterstützt.',
-        [Language.EE]: ''
+        [Language.EE]: '',
+        [Language.PL]: "Metody płatności (karty) nie są obsługiwane."
     },
     ErrorCodePayeeNotConfiguredForPayPal: {
         [Language.EN]: 'Payment method (PayPal) not supported.',
         [Language.DE]: 'Zahlungsmethode (PayPal) wird nicht unterstützt.',
-        [Language.EE]: 'Makseviisid (kaardid) ei ole toetatud.'
+        [Language.EE]: 'Makseviisid (kaardid) ei ole toetatud.',
+        [Language.PL]: "Metoda płatności (PayPal) nie jest obsługiwana."
     },
     ErrorCodePayeeRetrieveError: {
         [Language.EN]: 'Payee does not exist.',
         [Language.DE]: 'Zahlungsempfänger existiert nicht.',
-        [Language.EE]: 'Makse saaja ei ole olemas.'
+        [Language.EE]: 'Makse saaja ei ole olemas.',
+        [Language.PL]: "Odbiorca nie istnieje."
     },
     ErrorCodeInvalidPayer: {
         [Language.EN]: 'Invalid payer.',
         [Language.DE]: 'Ungültiger Bezahler.',
-        [Language.EE]: 'Invaliidne maksja.'
+        [Language.EE]: 'Invaliidne maksja.',
+        [Language.PL]: "Nieprawidłowy płatnik."
     },
     ErrorCodePayerRetrieveError: {
         [Language.EN]: 'Payer does not exist.',
         [Language.DE]: 'Bezahler exisitert nicht.',
-        [Language.EE]: 'Maksja ei ole olemas.'
+        [Language.EE]: 'Maksja ei ole olemas.',
+        [Language.PL]: "Płatnik nie istnieje."
     },
     ErrorCodePayerSaveMethodError: {
         [Language.EN]: 'Failed to store payment method.',
         [Language.DE]: 'Die Zahlungsmethode konnte nicht gespeichert werden.',
-        [Language.EE]: 'Makseviisi salvestamine ebaõnnestus.'
+        [Language.EE]: 'Makseviisi salvestamine ebaõnnestus.',
+        [Language.PL]: "Nie udało się zapisać metody płatności."
     },
     ErrorCodeInvalidMinimumAmount: {
         [Language.EN]: 'Payment amount falls below minimum amount.',
         [Language.DE]: 'Der Zahlungsbetrag fällt unter den Mindestbetrag.',
-        [Language.EE]: 'Maksesumma jääb alla miinimumsumma.'
+        [Language.EE]: 'Maksesumma jääb alla miinimumsumma.',
+        [Language.PL]: "Kwota płatności jest niższa od kwoty minimalnej."
     },
     ErrorCodeInvalidEmail: {
         [Language.EN]: 'Invalid email address. Please check your user data.',
         [Language.DE]: 'Ungültige E-Mail-Adresse. Bitte überprüfen Sie Ihre Benutzerdaten.',
-        [Language.EE]: 'Vale e-posti aadress. Palun kontrollige oma kasutajaandmeid.'
+        [Language.EE]: 'Vale e-posti aadress. Palun kontrollige oma kasutajaandmeid.',
+        [Language.PL]: "Nieprawidłowy adres e-mail. Sprawdź swoje dane użytkownika."
     },
     ErrorCodePaymentUseStoredMethodError: {
         [Language.EN]: 'Failed to use stored payment method.',
         [Language.DE]: 'Die gespeicherte Zahlungsmethode konnte nicht benutzt werden.',
-        [Language.EE]: 'Ei õnnestunud kasutada salvestatud makseviisi.'
+        [Language.EE]: 'Ei õnnestunud kasutada salvestatud makseviisi.',
+        [Language.PL]: "Nie udało się użyć zapisanej metody płatności."
     },
     ErrorCodePaymentRetrieveError: {
         [Language.EN]: 'Payment does not exist.',
         [Language.DE]: 'Zahlung existiert nicht.',
-        [Language.EE]: 'Makse ei ole olemas.'
+        [Language.EE]: 'Makse ei ole olemas.',
+        [Language.PL]: "Płatność nie istnieje."
     },
     ErrorCodePaymentCreationError: {
         [Language.EN]: 'Failed to create payment.',
         [Language.DE]: 'Die Zahlung konnte nicht erstellt werden.',
-        [Language.EE]: 'Makset ei õnnestunud luua.'
+        [Language.EE]: 'Makset ei õnnestunud luua.',
+        [Language.PL]: "Nie udało się utworzyć płatności."
     },
     ErrorCodePaymentCreateStripeMethodError: {
         [Language.EN]: 'Failed to initiate payment (Cards). Please contact support.',
         [Language.DE]: 'Die Zahlung konnte nicht gestartet werden (Kreditkarte). Bitte kontaktieren Sie den Support.',
-        [Language.EE]: 'Makset ei õnnestunud algatada (Cards). Palun võtke ühendust klienditoega.'
+        [Language.EE]: 'Makset ei õnnestunud algatada (Cards). Palun võtke ühendust klienditoega.',
+        [Language.PL]: "Nie udało się zainicjować płatności (karty). Skontaktuj się z pomocą techniczną."
     },
     ErrorCodePaymentCreatePayPalMethodError: {
         [Language.EN]: 'Failed to initiate payment (PayPal). Please contact support.',
         [Language.DE]: 'Die Zahlung konnte nicht gestartet werden (PayPal). Bitte kontaktieren Sie den Support.',
-        [Language.EE]: 'Makset ei õnnestunud algatada (PayPal). Palun võtke ühendust klienditoega.'
+        [Language.EE]: 'Makset ei õnnestunud algatada (PayPal). Palun võtke ühendust klienditoega.',
+        [Language.PL]: "Nie udało się zainicjować płatności (PayPal). Skontaktuj się z pomocą techniczną."
     },
     ErrorCodePaymentCapturePayPalError: {
         [Language.EN]: 'Failed to captured PayPal amount. Please contact support.',
         [Language.DE]: 'Die PayPal-Zahlung konnte nicht verarbeitet werden. Bitte kontaktieren Sie den Support.',
-        [Language.EE]: 'Ei õnnestunud jäädvustada PayPal summa. Palun võtke ühendust klienditoega.'
+        [Language.EE]: 'Ei õnnestunud jäädvustada PayPal summa. Palun võtke ühendust klienditoega.',
+        [Language.PL]: "Nie udało się zrealizować kwoty PayPal. Skontaktuj się z pomocą techniczną."
     },
     ErrorCodePaymentCreateWalleeMethodError: {
         [Language.EN]: 'Failed to initiate payment (Wallee). Please contact support.',
         [Language.DE]: 'Die Zahlung konnte nicht gestartet werden (Wallee). Bitte kontaktieren Sie den Support.',
-        [Language.EE]: 'Makset ei õnnestunud algatada (Wallee). Palun võtke ühendust klienditoega.'
+        [Language.EE]: 'Makset ei õnnestunud algatada (Wallee). Palun võtke ühendust klienditoega.',
+        [Language.PL]: "Nie udało się zainicjować płatności (Wallee). Skontaktuj się z pomocą techniczną."
     },
     ErrorOccurred: {
         [Language.EN]: "An error occurred. Code:",
         [Language.DE]: "Ein Fehler ist aufgetreten. Code:",
-        [Language.EE]: 'Tekkis viga. Kood:'
+        [Language.EE]: 'Tekkis viga. Kood:',
+        [Language.PL]: "Wystąpił błąd. Kod:"
     },
     Warning: {
         [Language.EN]: "Warning",
         [Language.DE]: "Warnung",
-        [Language.EE]: 'Hoiatus'
+        [Language.EE]: 'Hoiatus',
+        [Language.PL]: "Ostrzeżenie"
     },
     WalleePaymentRenewal: {
         [Language.EN]: "Restart Payment",
         [Language.DE]: "Zahlung erneut starten",
-        [Language.EE]: 'Uuenda makse'
+        [Language.EE]: 'Uuenda makse',
+        [Language.PL]: "Uruchom płatność ponownie"
     },
     WalleePaymentRenewalHint: {
         [Language.EN]: 'If you have accidentally close the payment processing page in TWINT or your payment method got rejected, you can use the "Restart Payment" button to retry the payment process again.',
         [Language.DE]: 'Wenn Sie versehentlich die Seite zur Zahlungsabwicklung bei TWINT geschlossen haben oder Ihre Zahlungsmethode abgelehnt wurde, können Sie die Schaltfläche "Zahlung erneut starten" verwenden, um den Zahlungsvorgang erneut zu versuchen.',
-        [Language.EE]: 'Kui sulgesite kogemata maksetöötluslehe TWINTis või teie makseviis lükati tagasi, saate makseprotsessi uuesti proovimiseks kasutada nuppu "Uuenda makse".'
+        [Language.EE]: 'Kui sulgesite kogemata maksetöötluslehe TWINTis või teie makseviis lükati tagasi, saate makseprotsessi uuesti proovimiseks kasutada nuppu "Uuenda makse".',
+        [Language.PL]: 'Jeśli przypadkowo zamknąłeś stronę przetwarzania płatności w TWINT lub Twoja metoda płatności została odrzucona, możesz użyć przycisku "Uruchom płatność ponownie", aby spróbować ponownie.'
     },
     WalleePaymentRenewalError: {
         [Language.EN]: 'Failed to restart payment.',
         [Language.DE]: 'Die Zahlung konnte nicht erneut gestartet werden.',
-        [Language.EE]: 'Makse uuendamine ebaõnnestus.'
+        [Language.EE]: 'Makse uuendamine ebaõnnestus.',
+        [Language.PL]: "Nie udało się ponownie uruchomić płatności."
     }
 });
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -30,6 +30,7 @@ export enum PaymentStatus {
 export enum PaymentType {
     Cards = 'Cards',
     SepaDirectDebit = 'SepaDirectDebit',
+    Blik = 'Blik',
     PayPal = 'PayPal',
     PaymentRequest = 'PaymentRequest'
 }


### PR DESCRIPTION
## Summary

Adds BLIK (Poland, PLN) as a Stripe payment method, fitting the existing per-element Stripe flow.

## Changes

- **types**: add `Blik` to `PaymentType` enum
- **stripe.tsx**: new `StripeBlikPayment` component — collects name, email and the 6-digit BLIK code, confirms via `stripe.confirmBlikPayment` (with the required `payment_method.blik` marker)
- **payment.tsx**: wire BLIK into the method list, type icon and `PaymentView`
- **resources**: BLIK strings (EN/DE/EE)
- **deps**: bump `@stripe/stripe-js` to `1.54.2` (where `confirmBlikPayment` is available); pin `@stripe/react-stripe-js` to `1.13.0` (1.16.x ships PayButton types broken against stripe-js v1)

## Notes

- BLIK is PLN-only and not savable — no save-method checkbox.
- Backend must return `stripe.type: 'Blik'` for PLN payments and enable BLIK in the Stripe dashboard.
- After submitting the code, the customer approves in their banking app; status resolves to processing/succeeded.

## Testing

- `tsc --noEmit` passes
- Manual BLIK submit verified against dev (pending backend `stripe-client-secret` returning a secret for BLIK)