### PR TITLE
ci: bump checkout/setup-node to v6 (Node 24)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,8 +11,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: 24
           registry-url: https://registry.npmjs.org


### PR DESCRIPTION
Bumps `actions/checkout@v4` → `@v6` and `actions/setup-node@v4` → `@v6`.

Both v4 actions run on the deprecated Node 20 runtime; GitHub forces those to Node 24 starting **2026-06-16**. The v6 actions run natively on Node 24 and clear the deprecation warning seen in recent CI runs. No behavior change to the build/publish steps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)